### PR TITLE
📝fix : 스페이스 생성 시 스페이스를 생성한 회원의 프로필 이미지가 스페이스 디폴트 이미지로 보여지는 에러를 해결함

### DIFF
--- a/src/main/java/com/app/kkiri/controller/SpaceController.java
+++ b/src/main/java/com/app/kkiri/controller/SpaceController.java
@@ -130,7 +130,6 @@ public class SpaceController {
 		spaceVO.setSpaceUserTally(1);
 
 		if(!multipartFile.isEmpty()){ // 사용자가 이미지를 지정한 경우
-
 			StringBuffer uploadPath = new StringBuffer();
 			StringBuffer uploadFileName = new StringBuffer();
 			StringBuffer uploadFullPathAndFileName = new StringBuffer();
@@ -156,20 +155,16 @@ public class SpaceController {
 			spaceVO.setSpaceIconPath(uploadFullPathAndFileName.toString()); // upload/space/2023/11/10/uuid_space.jpg
 			spaceVO.setSpaceIconUuid(uuid); // uuid
 			spaceVO.setSpaceIconSize(multipartFile.getSize()); // ...bytes
-
 		} else { // 기본이미지를 사용한 경우
-
 			Long defaultImg = spaceDTO.getDefaultImg();
-
 			if(defaultImg != null){
-
-				// ?? 디폴트 이미지 번호는 랜덤으로 생성되서 넘어오는가 ??
 				spaceVO.setSpaceIconName(defaultImg + ".jpg"); // 1.jpg
+				// 디폴트 이미지 번호는 프론트에서 넘어온다. (0 ~ 4)
+
 				spaceVO.setSpaceIconUuid("default"); // default
 				spaceVO.setSpaceIconPath(defaultRootPath + "/" + defaultImg + ".jpg"); // upload/default/1.jpg
 				spaceVO.setSpaceIconSize(0L); // 0L
 			} else {
-
 				throw new CustomException(StatusCode.MISSING_IMAGE);
 			}
 		}
@@ -178,14 +173,15 @@ public class SpaceController {
 		spaceUserVO.setUserId(userId);
 		spaceUserVO.setUserAdminYn(true);
 		spaceUserVO.setUserNickname("default");
-		spaceUserVO.setProfileImgName("default");
-		spaceUserVO.setProfileImgPath("default");
+		spaceUserVO.setProfileImgName("defaultProfile.png");
+		spaceUserVO.setProfileImgPath("upload/default/defaultProfile.png");
 		spaceUserVO.setProfileImgUuid("default");
+		// "" 빈문자열로 작성하면 DBMS 에서 null 로 인식하여 에러가 발생한다.
+		// 따라서 임의의 문자열인 "default" 를 기본값으로 저장한다.
+
 		spaceUserVO.setProfileImgSize(0L);
 
-		Long spaceId = spaceService.register(spaceVO, spaceUserVO);
-
-		return ResponseEntity.ok().body(spaceId);
+		return ResponseEntity.ok().body(spaceService.register(spaceVO, spaceUserVO));
 	}
 
 	// 스페이스 삭제
@@ -305,7 +301,7 @@ public class SpaceController {
 		HttpServletRequest request) throws IOException {
 
 		Long userId = getUserId(request);
-		log.info("userId: " + userId);
+		LOGGER.info("[]");
 
 		SpaceUserVO spaceUserVO = new SpaceUserVO();
 		spaceUserVO.setUserId(userId);


### PR DESCRIPTION
## #️⃣연관된 이슈
> 연관된 이슈 번호를 모두 작성해주세요
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 스페이스 생성 시 스페이스를 생성한 회원의 프로필 이미지를 스페이스 디폴트 이미지가 아닌, 프로필 디폴트 이미지로 설정하게 끔 코드를 수정했습니다.
- S3 버킷에 스페이스와 프로필 디폴트 이미지를 /default 디렉토리 하위에 추가하였습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?