### PR TITLE
🌈feat : 스페이스 생성 시 태그 목록을 추가하는 로직을 구현함

### DIFF
--- a/src/main/java/com/app/kkiri/controller/SpaceController.java
+++ b/src/main/java/com/app/kkiri/controller/SpaceController.java
@@ -102,8 +102,10 @@ public class SpaceController {
 	@PostMapping(value = "", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<?> register(
 		@RequestPart SpaceDTO spaceDTO,
+		@RequestPart(value = "tags") List<String> tagNames,
 		@RequestPart(required = false, value = "imgUrl") MultipartFile multipartFile,
 		HttpServletRequest request) throws IOException {
+		LOGGER.info("[register()] param spaceDTO : {}, multipartFile : {}, tagNames : {}", spaceDTO, multipartFile, tagNames);
 
 		Long userId = jwtTokenProvider.getUserIdByHeader(request);
 
@@ -168,13 +170,15 @@ public class SpaceController {
 
 		Long spaceId = spaceService.register(spaceVO, spaceUserVO);
 
-		List<TagVO> defaultTags = new ArrayList<>();
-		defaultTags.add(TagVO.builder().tagName("즐거운").spaceId(spaceId).build());
-		defaultTags.add(TagVO.builder().tagName("기억에 남는").spaceId(spaceId).build());
-		defaultTags.add(TagVO.builder().tagName("생일").spaceId(spaceId).build());
-		defaultTags.add(TagVO.builder().tagName("여행").spaceId(spaceId).build());
+		for (String tagName : tagNames) {
+			TagVO tagVO = TagVO.builder()
+				.tagName(tagName)
+				.spaceId(spaceId)
+				.build();
 
-		spaceService.addDefaultTags(defaultTags);
+			TagResponseDTO tagResponseDTO = spaceService.addTag(tagVO);
+			LOGGER.info("[register()] tagResponseDTO : {}", tagResponseDTO);
+		}
 
 		Map<String, Object> map = new HashMap<>();
 		map.put("spaceId", spaceId);

--- a/src/main/java/com/app/kkiri/domain/vo/SpaceVO.java
+++ b/src/main/java/com/app/kkiri/domain/vo/SpaceVO.java
@@ -2,12 +2,15 @@ package com.app.kkiri.domain.vo;
 
 import org.springframework.stereotype.Component;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Component
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class SpaceVO {
 	private Long spaceId;
 	private String spaceName;

--- a/src/main/java/com/app/kkiri/service/SpaceService.java
+++ b/src/main/java/com/app/kkiri/service/SpaceService.java
@@ -156,6 +156,7 @@ public class SpaceService {
 
 	// 스페이스 태그 조회
 	public  List<TagVO> tagList(Long spaceId){
+		LOGGER.info("[tagList()] param spaceId : {}", spaceId);
 
 		List<TagVO> tags = tagsDAO.findAll(spaceId);
 		LOGGER.info("[tagList()] tags : {}", tags);
@@ -164,7 +165,6 @@ public class SpaceService {
 	}
 
 	// 스페이스 태그 추가
-	@Transactional
 	public TagResponseDTO addTag(TagVO tagVO){
 
 		tagsDAO.save(tagVO);
@@ -173,17 +173,6 @@ public class SpaceService {
 		LOGGER.info("[addTag()] tagResponseDTO : {}", tagResponseDTO);
 
 		return tagResponseDTO;
-	}
-
-	// 디폴트 스페이스 태그 추가
-	@Transactional
-	public void addDefaultTags(List<TagVO> defaultTags){
-
-		for(TagVO tagVO : defaultTags) {
-			LOGGER.info("[addDefaultTags()] param tagVO : {}", tagVO);
-
-			tagsDAO.save(tagVO);
-		}
 	}
 
 	// 스페이스 태그 삭제

--- a/src/main/resources/mapper/TagsMapper.xml
+++ b/src/main/resources/mapper/TagsMapper.xml
@@ -27,11 +27,8 @@
 
     <select id="selectRecentTag" resultType="tagVO">
         SELECT tag_id, tag_name, space_id
-        FROM (
-                 SELECT tag_id, tag_name, space_id
-                 FROM tags
-                 ORDER BY tag_id DESC
-             ) D1
-        WHERE ROWNUM = 1
+        FROM tags
+        ORDER BY tag_id DESC
+        LIMIT 1
     </select>
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
> 연관된 이슈 번호를 모두 작성해주세요
> ex) #이슈번호, #이슈번호

#73 

## 📝작업 내용
- 백엔드 에서 스페이스 생성 후 기본 태그를 곧바로 생성하는 로직에서, 프론트 에서 기본 태그들의 목록을 스페이스 생성 시 함께 보내는 로직으로 수정했습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?