### PR TITLE
📝fix : space_id 가 2번인 스페이스의 게시물만 조회되는 에러를 해결함

### DIFF
--- a/src/main/resources/mapper/PostsMapper.xml
+++ b/src/main/resources/mapper/PostsMapper.xml
@@ -35,7 +35,7 @@
         FROM posts p
         LEFT JOIN post_tags t
         ON p.post_id=t.post_id
-        WHERE p.space_id = 2
+        WHERE p.space_id = #{spaceId}
         <if test="keyword != null">
             AND post_title LIKE CONCAT('%',#{keyword},'%')
         </if>
@@ -74,7 +74,7 @@
             SELECT DISTINCT(p.post_id) post_id, space_id
             FROM posts p LEFT JOIN post_tags t
             ON p.post_id=t.post_id
-            WHERE p.space_id=#{spaceId}
+            WHERE p.space_id = #{spaceId}
             <if test="keyword != null">
                 AND post_title LIKE CONCAT('%',#{keyword},'%')
             </if>


### PR DESCRIPTION
## #️⃣연관된 이슈
> 연관된 이슈 번호를 모두 작성해주세요
> ex) #이슈번호, #이슈번호

없음.

## 📝작업 내용
- client 로 부터 전달받은 space_id 를 SQL 문에서 사용하도록 SQL 문을 수정했습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

없음.