### PR TITLE
🌈feat : 스페이스 유저 정보 수정 시, 사용자가 프로필 이미지를 선택하지 않은 경우 기존 프로필을 유지하도록 기능을 구현함

### DIFF
--- a/src/main/java/com/app/kkiri/service/SpaceService.java
+++ b/src/main/java/com/app/kkiri/service/SpaceService.java
@@ -248,7 +248,7 @@ public class SpaceService {
 		try{
 			spaceUsersDAO.set(spaceUserVO);
 		} catch (Exception e){
-			// throw new CustomException(StatusCode.BAD_REQUEST);
+			throw new BadRequestException(INVALID_REQUEST);
 		}
 	}
 
@@ -267,4 +267,10 @@ public class SpaceService {
 
 		return spaceVO;
 	}
+
+	// space_id 와 user_id 를 사용하여 space_users 의 모든 데이터를 조회
+	public SpaceUserVO showSpaceUsers(Long spaceId, Long userId) {
+		return spaceUsersDAO.findById(spaceId, userId);
+	}
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> 연관된 이슈 번호를 모두 작성해주세요
> ex) #이슈번호, #이슈번호

#54 

## 📝작업 내용
- 스페이스 유저 정보 수정 시, 사용자가 프로필 이미지를 선택하지 않은 경우 기존 프로필을 유지하도록 기능을 구현했습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

없음.