### PR TITLE
🌈feat : OAuth2 로그인 시 리프레시 토큰이 만료된 경우 리프레시 토큰과 액세스 토큰을 재발급하는 로직을 구현함

### DIFF
--- a/src/main/java/com/app/kkiri/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/app/kkiri/security/jwt/JwtAuthenticationProvider.java
@@ -33,6 +33,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 		LOGGER.info("[authenticate()] param jwtAuthenticationToken : {}", jwtAuthenticationToken);
 
 		String accessToken = jwtAuthenticationToken.getJwt();
+
 		if(!jwtTokenProvider.validateToken(accessToken)) {
 			OAuth2Error oauth2Error = new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN);
 			throw new OAuth2AuthenticationException(oauth2Error, "만료된 토큰입니다");

--- a/src/main/java/com/app/kkiri/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/app/kkiri/security/jwt/JwtTokenProvider.java
@@ -111,19 +111,22 @@ public class JwtTokenProvider {
 	}
 
 	// 토큰의 유효성과 만료일 체크
-	public boolean validateToken(String token) {
+	public boolean validateToken(String token) throws ExpiredJwtException {
+
+		boolean result;
 
 		try {
 			Date expirationDate = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration();
-			boolean result = expirationDate.after(new Date());
-			LOGGER.info("[validateToken()] result : {}", result);
-
-			return result;
-		} catch (ExpiredJwtException ex) { // 토큰이 만료된 경우
-			throw new AuthException(EXPIRED_TOKEN);
-		} catch (JwtException ex){
+			result = expirationDate.after(new Date());
+		} catch (ExpiredJwtException e) { // UserService 에서 result 의 값을 사용하여 토큰을 재발급할 수 있도록 한다.
+			result = false;
+		} catch (JwtException e) {
 			throw new AuthException(INVALID_TOKEN);
 		}
+
+		LOGGER.info("[validateToken()] result : {}", result);
+
+		return result;
 	}
 
 	// 헤더에서 토큰 추출


### PR DESCRIPTION
## #️⃣연관된 이슈
> 연관된 이슈 번호를 모두 작성해주세요
> ex) #이슈번호, #이슈번호

#67

## 📝작업 내용
- OAuth2 로그인 시 리프레시 토큰이 만료된 경우 리프레시 토큰과 액세스 토큰을 재발급하는 로직을 구현했습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

없음.